### PR TITLE
Update checkout action to use latest version v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
 
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup Terraform
               uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This change updates the GitHub Actions workflow to use the latest version (v4) of the checkout action. It ensures compatibility with newer features and improvements provided by the updated version. Additionally, it helps maintain support and security updates for the workflow.